### PR TITLE
(fix): empty name and remove multiple nodes on singleplayer

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -82,12 +82,14 @@ formSinglePlayerButton.addEventListener('click', () => {
     isSinglePlayer = true;
     formView.className += ' invisible';
     dashboardRoomId.innerText = `Single Player Mode`;
+    while (gameViewRacers.childNodes.length > 1) gameViewRacers.removeChild(gameViewRacers.firstChild);
 });
 
 formMultiPlayerButton.addEventListener('click', () => {
+    let username;
+    formUsername.value === '' ? username = 'Guest' : username = formUsername.value;
     socket.connect();
     const roomId = formRoomId.value;
-    const username = formUsername.value;
     socket.emit('join', {roomId: roomId, username: username});
     isSinglePlayer = false;
     formView.className += ' invisible';

--- a/public/script.js
+++ b/public/script.js
@@ -86,11 +86,9 @@ formSinglePlayerButton.addEventListener('click', () => {
 });
 
 formMultiPlayerButton.addEventListener('click', () => {
-    let username;
-    formUsername.value === '' ? username = 'Guest' : username = formUsername.value;
     socket.connect();
     const roomId = formRoomId.value;
-    socket.emit('join', {roomId: roomId, username: username});
+    socket.emit('join', {roomId: roomId, username: formUsername.value || 'Guest'});
     isSinglePlayer = false;
     formView.className += ' invisible';
 });


### PR DESCRIPTION
greetings Akbarputra, @akbarhps.

### **the issue**
i found a bug where if a player connects on multiplayer then switched to the singleplayer mode, the multiplayer race node will merge with the singleplayer game view.

### **my approach on fixing it**
by waiting for the game to reset it's state, we could count the length of `gameViewRacers`, if there is more than one, then remove all except the last.